### PR TITLE
Fix zipcode download URL to new Japan Post path

### DIFF
--- a/data/update.sh
+++ b/data/update.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-URL="https://www.post.japanpost.jp/zipcode/dl/utf/zip/utf_ken_all.zip"
+URL="https://www.post.japanpost.jp/service/search/zipcode/download/utf/zip/utf_ken_all.zip"
 ZIP_FILE="utf_ken_all.zip"
 CSV_FILE="utf_ken_all.csv"
 TEMP_CSV="temp_utf_ken_all.csv"


### PR DESCRIPTION
## 概要

`data/update.sh` がダウンロードしていた日本郵便の郵便番号 ZIP の URL が 404 になり、「Update CSV and Create PR」ワークフローが連続失敗していたため修正します。

## 原因

日本郵便がダウンロードパスを移行し、旧 URL がエラー HTML を返すようになりました。`unzip` が `End-of-central-directory signature not found` で失敗し、`npm run update-csv` ステップが exit 1 で落ちていました。

- 旧（404）: `https://www.post.japanpost.jp/zipcode/dl/utf/zip/utf_ken_all.zip`
- 新（200）: `https://www.post.japanpost.jp/service/search/zipcode/download/utf/zip/utf_ken_all.zip`

## 検証

ローカルで新 URL を確認済み:
- `wget` で正常に DL（約2MB の正しい ZIP）
- `unzip` 成功、`utf_ken_all.csv`（124,511行）を取得

🤖 Generated with [Claude Code](https://claude.com/claude-code)